### PR TITLE
Implement helper modules

### DIFF
--- a/airport_lookup.py
+++ b/airport_lookup.py
@@ -1,20 +1,59 @@
-"""
-Airport lookup utilities for FlightHop.
+"""Airport lookup utilities for FlightHop.
 
-This module should load the airports.json data and provide functions to find
-airport information by IATA code, including coordinates, city, and country.
+This module loads airport information from ``airports.json`` and exposes helper
+functions for looking up airports by their IATA code.  Only a very small data
+set is bundled with the repository but the utility functions are written so
+that the data file can easily be expanded.
 """
 
-# TODO: Implement airport lookup functions
+from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Dict, Optional
 
-DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "airports.json"
+
+# The repository currently stores ``airports.json`` in the project root.  Using
+# ``Path(__file__).parent`` keeps the path working even if the module is moved
+# into a package later on.
+DATA_PATH = Path(__file__).resolve().parent / "airports.json"
+
 
 def load_airports() -> list:
+    """Load the list of airports from :data:`DATA_PATH`."""
     try:
-        with open(DATA_PATH, 'r', encoding='utf-8') as f:
+        with open(DATA_PATH, "r", encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
+        # In development the file might be missing; return an empty list so the
+        # caller can handle the situation gracefully.
         return []
+
+
+# Cache of airports keyed by IATA code.  ``load_airports`` is relatively cheap
+# but looking up airports repeatedly benefits from using a dictionary.
+_AIRPORT_CACHE: Dict[str, Dict] | None = None
+
+
+def _ensure_cache() -> None:
+    global _AIRPORT_CACHE
+    if _AIRPORT_CACHE is None:
+        _AIRPORT_CACHE = {a["iata"].upper(): a for a in load_airports()}
+
+
+def find_airport(iata: str) -> Optional[Dict]:
+    """Return airport information for ``iata`` or ``None`` if not found."""
+
+    _ensure_cache()
+    assert _AIRPORT_CACHE is not None  # for type checkers
+    return _AIRPORT_CACHE.get(iata.upper())
+
+
+def get_airport_name(iata: str) -> Optional[str]:
+    """Convenience wrapper returning only the airport name."""
+
+    airport = find_airport(iata)
+    if airport:
+        return airport.get("name")
+    return None
+

--- a/airports.json
+++ b/airports.json
@@ -1,1 +1,18 @@
-[]
+[
+  {
+    "iata": "STN",
+    "name": "London Stansted Airport",
+    "city": "London",
+    "country": "United Kingdom",
+    "lat": 51.885,
+    "lon": 0.235
+  },
+  {
+    "iata": "DUB",
+    "name": "Dublin Airport",
+    "city": "Dublin",
+    "country": "Ireland",
+    "lat": 53.4213,
+    "lon": -6.2701
+  }
+]

--- a/bot.py
+++ b/bot.py
@@ -1,18 +1,37 @@
-"""
-FlightHop bot entry point.
+"""Entry point for running simple FlightHop utilities.
 
-This script defines the Telegram bot handlers for the FlightHop game. It uses
-python-telegram-bot to handle commands, guesses, and daily progression.
-
-Note: This is a placeholder implementation. You need to implement the actual
-bot logic, including loading routes from data/routes.json, tracking per-group
-state in data/state.json, and responding to user guesses.
+The real Telegram bot is not implemented yet, but this module exposes a small
+command–line interface that demonstrates the helper functions found in the
+project.  It is intentionally lightweight so that the repository remains easy to
+understand for newcomers.
 """
 
-# TODO: Implement the FlightHop bot using python-telegram-bot
+from __future__ import annotations
 
-def main():
-    print("FlightHop bot is not yet implemented. Please see README.md for details.")
+import argparse
+
+from airport_lookup import find_airport
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="FlightHop helper CLI")
+    parser.add_argument(
+        "--lookup",
+        metavar="IATA",
+        help="Lookup an airport by IATA code and print basic information",
+    )
+    args = parser.parse_args()
+
+    if args.lookup:
+        airport = find_airport(args.lookup)
+        if airport:
+            print(
+                f"{airport['iata']} - {airport['name']} ({airport['city']}, {airport['country']})"
+            )
+        else:
+            print(f"Airport '{args.lookup}' not found.")
+    else:
+        parser.print_help()
 
 if __name__ == "__main__":
     main()

--- a/game_state.py
+++ b/game_state.py
@@ -1,19 +1,26 @@
-"""
-Game state utilities for FlightHop.
+"""Utilities for persisting and manipulating the per-group game state."""
 
-This module should define functions and classes to manage the state of each
-Telegram group playing the FlightHop game. State includes current leg index,
-correct guesses, and last played timestamps.
-"""
+from __future__ import annotations
 
-# TODO: Implement state management functions
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+
+# ``state.json`` lives in the repository root.  The file format is very simple
+# and intentionally kept human readable so that it can be edited during
+# development.
+STATE_PATH = Path(__file__).resolve().parent / "state.json"
+
 
 class GameState:
-    def __init__(self, group_id: int):
+    """Representation of a single Telegram group's progress."""
+
+    def __init__(self, group_id: int) -> None:
         self.group_id = group_id
         self.current_leg = 0
-        self.guesses = []
-        self.last_played = None
+        self.guesses: list[str] = []
+        self.last_played: Optional[str] = None  # ISO formatted date string
 
     def to_dict(self) -> dict:
         return {
@@ -22,3 +29,46 @@ class GameState:
             "guesses": self.guesses,
             "last_played": self.last_played,
         }
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "GameState":
+        obj = cls(data.get("group_id", 0))
+        obj.current_leg = data.get("current_leg", 0)
+        obj.guesses = list(data.get("guesses", []))
+        obj.last_played = data.get("last_played")
+        return obj
+
+    def record_guess(self, iata: str) -> None:
+        self.guesses.append(iata.upper())
+
+
+def _load_raw_states() -> Dict[str, Dict]:
+    try:
+        with open(STATE_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data.get("group_states", {})
+    except FileNotFoundError:
+        return {}
+
+
+def _save_raw_states(states: Dict[str, Dict]) -> None:
+    with open(STATE_PATH, "w", encoding="utf-8") as f:
+        json.dump({"group_states": states}, f, indent=2)
+
+
+def load_state(group_id: int) -> GameState:
+    """Load the :class:`GameState` for ``group_id`` creating a new one if needed."""
+
+    states = _load_raw_states()
+    if str(group_id) in states:
+        return GameState.from_dict(states[str(group_id)])
+    return GameState(group_id)
+
+
+def save_state(state: GameState) -> None:
+    """Persist ``state`` back to :data:`STATE_PATH`."""
+
+    states = _load_raw_states()
+    states[str(state.group_id)] = state.to_dict()
+    _save_raw_states(states)
+

--- a/message_utils.py
+++ b/message_utils.py
@@ -1,11 +1,27 @@
-"""
-Message formatting utilities for FlightHop.
+"""Helpers for formatting user-facing messages used by the bot."""
 
-This module should include helper functions to format bot messages, such as
-formatting guesses, progress notifications, and stewardess tips.
-"""
+from __future__ import annotations
 
-# TODO: Implement message formatting functions
 
 def format_correct_guess(iata: str, airport_name: str, country_flag: str) -> str:
+    """Return a success message for a correct IATA guess."""
+
     return f"✅ Correct! You’ve landed at {iata} ({airport_name}) {country_flag}"
+
+
+def format_incorrect_guess(iata: str) -> str:
+    """Return a gentle message for an incorrect guess."""
+
+    return f"❌ {iata.upper()} isn't the destination. Try again!"
+
+
+def format_daily_challenge(map_link: str) -> str:
+    """Return the daily challenge introduction with a map link."""
+
+    lines = [
+        "🛫 FlightHop Challenge of the Day!",
+        "🌍 Where in the world are we today? Tap the map and guess the IATA code.",
+        f"\n📍 {map_link}",
+    ]
+    return "\n".join(lines)
+


### PR DESCRIPTION
## Summary
- flesh out airport lookup with simple caching and helper function
- implement message formatting helpers
- create minimal persistence utilities for game state
- add a lightweight CLI in `bot.py`
- populate `airports.json` with two example airports

## Testing
- `python -m py_compile airport_lookup.py message_utils.py game_state.py bot.py`
- `python bot.py --lookup DUB`
- `python bot.py --lookup XXX`


------
https://chatgpt.com/codex/tasks/task_e_6885ef3b22348323b019de1a3c3f1f0a